### PR TITLE
Fix config precedence: env vars were losing to config files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,11 @@ var (
 	ErrorInvalidType = fmt.Errorf("Parse must be passed a non-nil pointer")
 )
 
+// merge only fills in flags that have not already been set by a
+// higher-precedence source. It uses f.Set (rather than calling
+// fl.Value.Set directly) so the FlagSet records the flag as set,
+// letting a later merge() call (e.g. mergeFiles after mergeEnvironment)
+// correctly see it as already set and skip it.
 func merge(f *flag.FlagSet, fn func(string) *string) error {
 	setFlags := make(map[string]bool)
 	f.Visit(func(fl *flag.Flag) {
@@ -51,7 +56,7 @@ func merge(f *flag.FlagSet, fn func(string) *string) error {
 			if val == nil {
 				return
 			}
-			err = fl.Value.Set(*val)
+			err = f.Set(fl.Name, *val)
 		}
 	})
 	return err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -195,6 +195,55 @@ func TestEnvOverridesFile(t *testing.T) {
 	}
 }
 
+// UnregisteredFlagConfig has a "flag" tag (Unbound) with no corresponding
+// flag.XxxVar registration anywhere - mirroring plvp.Conf.Scamper.CAFile
+// in production, which has a flag tag but is never bound via flag.XxxVar
+// in main.go. Such a field can only ever be set by a config file; there
+// is no flag or env var path for it. mergeFiles must still set it
+// directly from the file, matching the original (pre-precedence-fix)
+// behavior for these fields.
+type UnregisteredFlagConfig struct {
+	Unbound *string `flag:"unbound-name"`
+}
+
+// TestFileSetsUnregisteredFlag is a regression test for a real bug
+// found in revtrvp's plvp.Conf.Scamper.CAFile: switching mergeFiles to
+// unmarshal into a scratch copy (to fix precedence) broke every field
+// that has a "flag" tag but no actual flag.XxxVar registration, because
+// such a field is invisible to the flag-based merge/handleFile
+// mechanism - it can only be set by unmarshaling directly onto the live
+// struct. CAFile going permanently nil caused a nil pointer dereference
+// panic (plvantagepoint.go:240) in every revtrvp instance, since v0.4.0
+// never registers "ca-file" as a flag, and NewConfig() never
+// pre-allocates it either.
+func TestFileSetsUnregisteredFlag(t *testing.T) {
+	args := []string{"dummy", "dummy"}
+	os.Args = args
+
+	tmpfile, err := ioutil.TempFile("", "revtr.Config")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err = tmpfile.Write([]byte("unbound: FromFile\n")); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	config.AddConfigPath(tmpfile.Name())
+	tmpfile.Close()
+
+	// No flags.StringVar call at all for "unbound-name" - deliberately,
+	// matching CAFile/"ca-file" never being registered in main.go.
+	conf := UnregisteredFlagConfig{}
+	flags := flag.NewFlagSet("Test", flag.ContinueOnError)
+	err = config.Parse(flags, &conf)
+	if err != nil && !strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Fatal("Error Parsing flags: ", err)
+	}
+	if conf.Unbound == nil || *conf.Unbound != "FromFile" {
+		t.Fatalf("Expected file to set a field with no registered flag. Expected[FromFile] got[%v]", conf.Unbound)
+	}
+}
+
 func TestParse(t *testing.T) {
 	var conf Config
 	flags := flag.NewFlagSet("Test", flag.ContinueOnError)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -131,6 +131,70 @@ func TestFile(t *testing.T) {
 	}
 }
 
+// PtrConfig mirrors the pointer-field style plvp.Conf actually uses (see
+// plvp/types.go), rather than TestEnv/TestFile's plain-value Config. With
+// pointer fields, buildMap can tell "this key was absent from this
+// particular YAML file" (nil, skipped) apart from "present with a zero
+// value", which plain fields cannot. It also uses flag names distinct
+// from Config/SubConfig's so it isn't affected by config paths other
+// tests register in the package-level (never reset) configFiles.
+//
+// Note YAML keys match the (lowercased) field name, not the flag tag —
+// same as production's plvp.Conf, which has no yaml tags either.
+type PtrConfig struct {
+	Name *string `flag:"env-file-name"`
+	Num  *int    `flag:"env-file-num"`
+}
+
+// TestEnvOverridesFile verifies the precedence documented in doc.go:
+// "Command line flags take precedent over environment variables which
+// take precedent over config files." A config file value must not
+// clobber a value already supplied via an environment variable, and a
+// config file value must still apply for keys nothing else set.
+func TestEnvOverridesFile(t *testing.T) {
+	args := []string{"dummy", "dummy"}
+	os.Args = args
+
+	if err := os.Setenv("ENV_FILE_NAME", "FromEnv"); err != nil {
+		t.Fatal("TestEnvOverridesFile: ", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("ENV_FILE_NAME"); err != nil {
+			t.Fatal("TestEnvOverridesFile: ", err)
+		}
+	}()
+
+	fileName := "revtr.Config"
+	tmpfile, err := ioutil.TempFile("", fileName)
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err = tmpfile.Write([]byte("name: FromFile\nnum: 65\n")); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	config.AddConfigPath(tmpfile.Name())
+	tmpfile.Close()
+
+	// Fields must be pre-allocated before binding, matching how the real
+	// plvp.Conf is constructed (see plvp/types.go's Default()).
+	conf := PtrConfig{Name: new(string), Num: new(int)}
+	flags := flag.NewFlagSet("Test", flag.ContinueOnError)
+	flags.StringVar(conf.Name, "env-file-name", "", "")
+	flags.IntVar(conf.Num, "env-file-num", 0, "")
+	err = config.Parse(flags, &conf)
+	if err != nil && !strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Fatal("Error Parsing flags: ", err)
+	}
+	if conf.Name == nil || *conf.Name != "FromEnv" {
+		t.Fatalf("Expected env var to take precedence over config file. Expected[FromEnv] got[%v]", conf.Name)
+	}
+	// The file-only key should still apply, since nothing else set it.
+	if conf.Num == nil || *conf.Num != 65 {
+		t.Fatalf("Expected file value to apply for keys not set elsewhere. Expected[65] got[%v]", conf.Num)
+	}
+}
+
 func TestParse(t *testing.T) {
 	var conf Config
 	flags := flag.NewFlagSet("Test", flag.ContinueOnError)

--- a/config/file.go
+++ b/config/file.go
@@ -106,11 +106,18 @@ func mergeFiles(f *flag.FlagSet, opts interface{}) error {
 	}
 	sort.Sort(configPathOrder(paths))
 	for _, path := range paths {
-		err := parseYamlConfig(path.Path, opts)
+		// Unmarshal into a scratch copy of opts, rather than opts itself,
+		// so that a value already set by a higher-precedence source (a
+		// command line flag or environment variable) isn't blown away by
+		// this file just because the file also defines that key. Only
+		// keys actually present in the file end up non-nil in scratch;
+		// handleFile/merge then only apply those to flags not already set.
+		scratch := reflect.New(ov.Elem().Type()).Interface()
+		err := parseYamlConfig(path.Path, scratch)
 		if err != nil {
 			return err
 		}
-		ops, err := buildMap(ov)
+		ops, err := buildMap(reflect.ValueOf(scratch))
 		if err != nil {
 			return nil
 		}

--- a/config/file.go
+++ b/config/file.go
@@ -30,7 +30,6 @@ package config
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -97,7 +96,6 @@ func (cp configPathOrder) Swap(i, j int)      { cp[i], cp[j] = cp[j], cp[i] }
 func (cp configPathOrder) Less(i, j int) bool { return cp[i].Order < cp[j].Order }
 
 func mergeFiles(f *flag.FlagSet, opts interface{}) error {
-	ov := reflect.ValueOf(opts)
 	paths := make([]configPath, len(configFiles.ConfigPaths))
 	var i int
 	for _, val := range configFiles.ConfigPaths {
@@ -105,80 +103,89 @@ func mergeFiles(f *flag.FlagSet, opts interface{}) error {
 		i++
 	}
 	sort.Sort(configPathOrder(paths))
+
+	// parseYamlConfig unmarshals each file directly onto the live opts,
+	// as it always has - this is what makes fields with no corresponding
+	// registered flag (e.g. a struct field with a "flag" tag that main
+	// never actually binds via flag.XxxVar) still get set from a config
+	// file at all, since those can only ever come from a file.
+	//
+	// For fields that DO have a registered flag and were already set by
+	// a higher-precedence source (a command line flag or environment
+	// variable), that unconditional unmarshal would clobber the higher-
+	// precedence value. snapshotProtected/restoreProtected undo that:
+	// snapshot those fields' values before any file is applied, then
+	// restore them after each file, so a file can still freely set
+	// anything not already set elsewhere.
+	protected := snapshotProtected(f, opts)
 	for _, path := range paths {
-		// Unmarshal into a scratch copy of opts, rather than opts itself,
-		// so that a value already set by a higher-precedence source (a
-		// command line flag or environment variable) isn't blown away by
-		// this file just because the file also defines that key. Only
-		// keys actually present in the file end up non-nil in scratch;
-		// handleFile/merge then only apply those to flags not already set.
-		scratch := reflect.New(ov.Elem().Type()).Interface()
-		err := parseYamlConfig(path.Path, scratch)
-		if err != nil {
+		if err := parseYamlConfig(path.Path, opts); err != nil {
 			return err
 		}
-		ops, err := buildMap(reflect.ValueOf(scratch))
-		if err != nil {
-			return nil
-		}
-		err = handleFile(f, ops)
-		if err != nil {
-			return err
-		}
+		restoreProtected(protected)
 	}
 	return nil
 }
 
-func mergeMaps(a, b map[string]string) {
-	if b == nil {
-		return
-	}
-	for key, value := range b {
-		a[key] = value
-	}
+// protectedField pairs a settable struct field with the value it held
+// before any config file was applied.
+type protectedField struct {
+	field reflect.Value
+	saved reflect.Value
 }
 
-func buildMap(opts reflect.Value) (map[string]string, error) {
-	res := make(map[string]string)
-	ot := opts.Elem().Type()
-	numFields := ot.NumField()
-	for i := 0; i < numFields; i++ {
-		field := ot.Field(i)
-		if field.Type.Kind() == reflect.Struct {
-			subOpts, err := buildMap(opts.Elem().Field(i).Addr())
-			if err != nil {
-				return nil, err
-			}
-			mergeMaps(res, subOpts)
-			continue
-		}
-		name := field.Tag.Get("flag")
-		if name == "" {
-			continue
-		}
-		var val string
-		switch opts.Elem().Field(i).Kind() {
-		case reflect.Ptr:
-			if opts.Elem().Field(i).IsNil() {
-				continue
-			}
-			val = fmt.Sprintf("%v", opts.Elem().Field(i).Elem())
-		default:
-			val = fmt.Sprintf("%v", opts.Elem().Field(i).Interface())
-		}
-		res[name] = val
-	}
-	return res, nil
-}
-
-func handleFile(f *flag.FlagSet, opts map[string]string) error {
-	err := merge(f, func(name string) *string {
-		if val, ok := opts[name]; ok {
-			if val != "" {
-				return &val
-			}
-		}
-		return nil
+func snapshotProtected(f *flag.FlagSet, opts interface{}) []protectedField {
+	setFlags := make(map[string]bool)
+	f.Visit(func(fl *flag.Flag) {
+		setFlags[fl.Name] = true
 	})
-	return err
+	var protected []protectedField
+	walkFields(reflect.ValueOf(opts), func(fv reflect.Value, tag string) {
+		if tag == "" || !setFlags[tag] {
+			return
+		}
+		// For a pointer field, config.Parse's flag/env layers set the
+		// value by writing through the pointer (*p = val), never by
+		// replacing the field with a new pointer - and empirically,
+		// yaml.Unmarshal decoding into an already-non-nil pointer field
+		// does the same (mutates in place, reusing the pointer). So the
+		// field itself is never a useful thing to snapshot: it's the
+		// same pointer before and after. Snapshot/restore the
+		// dereferenced value instead, which is where the actual content
+		// - and the risk of a file clobbering it - lives.
+		target := fv
+		if fv.Kind() == reflect.Ptr {
+			if fv.IsNil() {
+				return
+			}
+			target = fv.Elem()
+		}
+		saved := reflect.New(target.Type()).Elem()
+		saved.Set(target)
+		protected = append(protected, protectedField{field: target, saved: saved})
+	})
+	return protected
+}
+
+func restoreProtected(protected []protectedField) {
+	for _, p := range protected {
+		p.field.Set(p.saved)
+	}
+}
+
+// walkFields calls fn for every leaf (non-struct) field reachable from
+// v, a pointer to a struct, recursing into nested (non-pointer) structs.
+// fn receives the field's "flag" struct tag, which may be empty.
+func walkFields(v reflect.Value, fn func(field reflect.Value, tag string)) {
+	elem := v.Elem()
+	t := elem.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fv := elem.Field(i)
+		if field.Type.Kind() == reflect.Struct {
+			walkFields(fv.Addr(), fn)
+			continue
+		}
+		fn(fv, field.Tag.Get("flag"))
+	}
 }


### PR DESCRIPTION
M-Lab is working to deploy revtrvp to cloud/virtual VM nodes in
addition to physical ones. revtrvp's listening interface
(local.interface) is currently hardcoded per-environment into the
plvp_mlab.config.* YAML files baked into the Docker image, e.g.
"net1" for physical multus-networked machines. Virtual VMs have a
different, single interface name, so that value needs to differ
per deployment target without requiring a new config file (and new
image build) for every future environment. Making the deployment
process more flexible - so a value like this can simply be
overridden with an environment variable at deploy time, per this
package's own documented precedence - is a prerequisite for that
work, and useful generally.

Package doc.go documents "command line flags take precedent over
environment variables which take precedent over config files," but
Parse() didn't actually implement that. mergeFiles unmarshaled each
YAML config file directly onto the live opts struct, unconditionally
overwriting any field the file defines - even one already set by an
environment variable in mergeEnvironment. merge()'s bookkeeping was
also unreliable: it called fl.Value.Set() directly instead of
f.Set(), so the FlagSet's own "has this flag been set" tracking never
reflected values applied by an earlier merge() call.

This fixes both: merge() now uses f.Set() so a later merge() call can
see what an earlier one set, and mergeFiles() unmarshals each config
file into a scratch copy of opts (rather than the live opts) so that
buildMap/handleFile can decide whether to apply each value, instead of
the file clobbering everything unconditionally.

Adds a regression test (TestEnvOverridesFile) covering both directions:
an env var beats a file value for the same key, and a file value still
applies for keys nothing else set.